### PR TITLE
Discard master and slave language

### DIFF
--- a/Services/MySQL/60_mysql.py
+++ b/Services/MySQL/60_mysql.py
@@ -25,7 +25,7 @@ metric={
 'Threads_running':0,
 'Bytes_sent':0,
 'Bytes_received':0,
-'slave':1,
+'subordinate':1,
 'alive':0,
 }
 
@@ -66,12 +66,12 @@ def get_mysqladmin_extended_status():
 	if 'alive' in ping: metric['alive']=1
 	data.append({'endpoint':endpoint,'timstamp':long(ts),'step': step,'metric':'mysql.alive','value':long(metric['alive']),'tags':"",'counterType':'GAUGE'})
 
-	slaveMetric=['Slave_IO_Running','Slave_SQL_Running','Seconds_Behind_Master']
-	cmd='%s %s -e  "show slave status\G"' % (mysql, db_auth)
+	subordinateMetric=['Subordinate_IO_Running','Subordinate_SQL_Running','Seconds_Behind_Main']
+	cmd='%s %s -e  "show subordinate status\G"' % (mysql, db_auth)
 	sstat=commands.getoutput(cmd).split('\n')[1:]
 	if sstat[11].split(':')[1].strip() == 'No' or sstat[12].split(':')[1].strip() == 'No':
-		metric['slave']=0
-	data.append({'endpoint':endpoint,'timstamp':long(ts),'step': step,'metric':'mysql.slave','value':long(metric['slave']),'tags':"",'counterType':'GAUGE'})
+		metric['subordinate']=0
+	data.append({'endpoint':endpoint,'timstamp':long(ts),'step': step,'metric':'mysql.subordinate','value':long(metric['subordinate']),'tags':"",'counterType':'GAUGE'})
 	data.append({'endpoint':endpoint,'timstamp':long(ts),'step': step,'metric':'mysql.behind','value':long(sstat[33].split(':')[1].strip()),'tags':"",'counterType':'GAUGE'})
 
 	print json.dumps(data,indent=4)

--- a/Services/monitor/60_mysql.py
+++ b/Services/monitor/60_mysql.py
@@ -24,7 +24,7 @@ metric={
 'Threads_running':0,
 'Bytes_sent':0,
 'Bytes_received':0,
-'slave':1,
+'subordinate':1,
 'alive':0,
 }
 
@@ -65,13 +65,13 @@ def get_mysqladmin_extended_status():
 	if 'alive' in ping: metric['alive']=1
 	data.append({'endpoint':endpoint,'timstamp':long(ts),'step': step,'metric':'mysql.alive','value':long(metric['alive']),'tags':"",'counterType':'GAUGE'})
 
-	### slave status monitor
-	#slaveMetric=['Slave_IO_Running','Slave_SQL_Running','Seconds_Behind_Master']
-	#cmd='%s %s -e  "show slave status\G"' % (mysql, db_auth)
+	### subordinate status monitor
+	#subordinateMetric=['Subordinate_IO_Running','Subordinate_SQL_Running','Seconds_Behind_Main']
+	#cmd='%s %s -e  "show subordinate status\G"' % (mysql, db_auth)
 	#sstat=commands.getoutput(cmd).split('\n')[1:]
 	#if sstat[11].split(':')[1].strip() == 'No' or sstat[12].split(':')[1].strip() == 'No':
-	#	metric['slave']=0
-	#data.append({'endpoint':endpoint,'timstamp':long(ts),'step': step,'metric':'mysql.slave','value':long(metric['slave']),'tags':"",'counterType':'GAUGE'})
+	#	metric['subordinate']=0
+	#data.append({'endpoint':endpoint,'timstamp':long(ts),'step': step,'metric':'mysql.subordinate','value':long(metric['subordinate']),'tags':"",'counterType':'GAUGE'})
 	#data.append({'endpoint':endpoint,'timstamp':long(ts),'step': step,'metric':'mysql.behind','value':long(sstat[33].split(':')[1].strip()),'tags':"",'counterType':'GAUGE'})
 
 	print json.dumps(data,indent=4)

--- a/Services/monitor/mysql.py
+++ b/Services/monitor/mysql.py
@@ -25,7 +25,7 @@ metric={
 'Threads_running':0,
 'Bytes_sent':0,
 'Bytes_received':0,
-'slave':1,
+'subordinate':1,
 'alive':0,
 }
 
@@ -66,12 +66,12 @@ def get_mysqladmin_extended_status():
 	if 'alive' in ping: metric['alive']=1
 	data.append({'endpoint':endpoint,'timstamp':long(ts),'step': step,'metric':'mysql.alive','value':long(metric['alive']),'tags':"",'counterType':'GAUGE'})
 
-	slaveMetric=['Slave_IO_Running','Slave_SQL_Running','Seconds_Behind_Master']
-	cmd='%s %s -e  "show slave status\G"' % (mysql, db_auth)
+	subordinateMetric=['Subordinate_IO_Running','Subordinate_SQL_Running','Seconds_Behind_Main']
+	cmd='%s %s -e  "show subordinate status\G"' % (mysql, db_auth)
 	sstat=commands.getoutput(cmd).split('\n')[1:]
 	if sstat[11].split(':')[1].strip() == 'No' or sstat[12].split(':')[1].strip() == 'No':
-		metric['slave']=0
-	data.append({'endpoint':endpoint,'timstamp':long(ts),'step': step,'metric':'mysql.slave','value':long(metric['slave']),'tags':"",'counterType':'GAUGE'})
+		metric['subordinate']=0
+	data.append({'endpoint':endpoint,'timstamp':long(ts),'step': step,'metric':'mysql.subordinate','value':long(metric['subordinate']),'tags':"",'counterType':'GAUGE'})
 	data.append({'endpoint':endpoint,'timstamp':long(ts),'step': step,'metric':'mysql.behind','value':long(sstat[33].split(':')[1].strip()),'tags':"",'counterType':'GAUGE'})
 
 	print json.dumps(data,indent=4)

--- a/Services/openfalcon/60_mysql_status.py
+++ b/Services/openfalcon/60_mysql_status.py
@@ -30,7 +30,7 @@ StrDict={
 	'not':0
 }
 
-monitor_blackList=['Ssl_','Performance_schema','Com_show_','Com_drop_','Com_create_','Com_alter_','Binlog_','Slave_','Tc_log_']
+monitor_blackList=['Ssl_','Performance_schema','Com_show_','Com_drop_','Com_create_','Com_alter_','Binlog_','Subordinate_','Tc_log_']
 monitor_whiteList=["Bytes_received",
 "Bytes_sent",
 "Threads_connected", 
@@ -79,7 +79,7 @@ DataType ={
 
 	"Binlog_event_count": DELTA_PS,
 	"Binlog_number":      DELTA_PS,
-	"Slave_count":        DELTA_PS,
+	"Subordinate_count":        DELTA_PS,
 
 	"Com_admin_commands":        DELTA_PS,
 	"Com_assign_to_keycache":    DELTA_PS,
@@ -96,7 +96,7 @@ DataType ={
 	"Com_binlog":                DELTA_PS,
 	"Com_call_procedure":        DELTA_PS,
 	"Com_change_db":             DELTA_PS,
-	"Com_change_master":         DELTA_PS,
+	"Com_change_main":         DELTA_PS,
 	"Com_check":                 DELTA_PS,
 	"Com_checksum":              DELTA_PS,
 	"Com_commit":                DELTA_PS,
@@ -182,7 +182,7 @@ DataType ={
 	"Com_show_function_status":  DELTA_PS,
 	"Com_show_grants":           DELTA_PS,
 	"Com_show_keys":             DELTA_PS,
-	"Com_show_master_status":    DELTA_PS,
+	"Com_show_main_status":    DELTA_PS,
 	"Com_show_open_tables":      DELTA_PS,
 	"Com_show_plugins":          DELTA_PS,
 	"Com_show_privileges":       DELTA_PS,
@@ -191,8 +191,8 @@ DataType ={
 	"Com_show_profile":          DELTA_PS,
 	"Com_show_profiles":         DELTA_PS,
 	"Com_show_relaylog_events":  DELTA_PS,
-	"Com_show_slave_hosts":      DELTA_PS,
-	"Com_show_slave_status":     DELTA_PS,
+	"Com_show_subordinate_hosts":      DELTA_PS,
+	"Com_show_subordinate_status":     DELTA_PS,
 	"Com_show_status":           DELTA_PS,
 	"Com_show_storage_engines":  DELTA_PS,
 	"Com_show_table_status":     DELTA_PS,
@@ -200,8 +200,8 @@ DataType ={
 	"Com_show_triggers":         DELTA_PS,
 	"Com_show_variables":        DELTA_PS,
 	"Com_show_warnings":         DELTA_PS,
-	"Com_slave_start":           DELTA_PS,
-	"Com_slave_stop":            DELTA_PS,
+	"Com_subordinate_start":           DELTA_PS,
+	"Com_subordinate_stop":            DELTA_PS,
 	"Com_stmt_close":            DELTA_PS,
 	"Com_stmt_execute":          DELTA_PS,
 	"Com_stmt_fetch":            DELTA_PS,


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.